### PR TITLE
bumping files version from 1.3.3 to 1.3.4

### DIFF
--- a/playbooks/roles/files/defaults/main/images.yml
+++ b/playbooks/roles/files/defaults/main/images.yml
@@ -1,5 +1,5 @@
-files_api_image: tapis/tapis-files:1.3.3
-files_workers_image: tapis/tapis-files-workers:1.3.3
+files_api_image: tapis/tapis-files:1.3.4
+files_workers_image: tapis/tapis-files-workers:1.3.4
 files_postgres_image: postgres:11
 files_minio_image: minio/minio
 files_irods_provider_postgres_image: mjstealey/irods-provider-postgres:4.2.4


### PR DESCRIPTION
Please move files images from 1.3.3 to 1.3.4, and generate the new tapis-kube in production.  We will restart files when the new code is deployed - you don't need to restart it.