### PR TITLE
Specify service account for security API initContainer

### DIFF
--- a/playbooks/roles/security/templates/kube/api/api.yml
+++ b/playbooks/roles/security/templates/kube/api/api.yml
@@ -12,6 +12,9 @@ spec:
         app: sk-api
     spec:
 {% if security_renew_sk_script == true %}
+{% if skadmin_sk_privileged_sa is not none %}
+      serviceAccountName: {{ skadmin_sk_privileged_sa }}
+{% endif %}
       initContainers:
       - name: renew-sk-secret
         command: ["/tmp/renew-sk-secret-script"]


### PR DESCRIPTION
When running the security API deployment with the optional initContainer "renew-sk-secret", that container needs to run under a privileged service account or else renew-sk-secret doesn't get created. I embedded the statement inside the conditional for the initContainer, so that the privileged service account isn't used unless needed.  I couldn't find a way to have the SA apply only to the initContainer.