### PR TITLE
Allow sk-admin-update to create Kubernetes secrets

### DIFF
--- a/playbooks/roles/skadmin/templates/kube/updateSecrets/sk-admin-update.yml
+++ b/playbooks/roles/skadmin/templates/kube/updateSecrets/sk-admin-update.yml
@@ -7,6 +7,9 @@ metadata:
 spec:
   template:
     spec:
+{% if skadmin_sk_privileged_sa is not none %}
+      serviceAccountName: {{ skadmin_sk_privileged_sa }}
+{% endif %}
       restartPolicy: Never
       containers:
       - name: sk-admin-update


### PR DESCRIPTION
Specify a serviceAccountName when the default service account doesn't have the roleBinding necessary to create Kubernetes secrets.