### PR TITLE
Kube nginx

### DIFF
--- a/playbooks/roles/proxy/templates/docker/locations/actors.conf
+++ b/playbooks/roles/proxy/templates/docker/locations/actors.conf
@@ -4,9 +4,9 @@ location /v3/actors
     auth_request /_auth;
     error_page 500 /token-revoked.json; 
 
-    # use var to allow nginx to start even if $upstream is down
-    set $upstream http://actors-nginx:80;
-    proxy_pass $upstream;
+    
+    proxy_pass http://actors-nginx:80;
+    
 
     proxy_redirect off;
     proxy_set_header Host $host;

--- a/playbooks/roles/proxy/templates/docker/locations/actors.conf
+++ b/playbooks/roles/proxy/templates/docker/locations/actors.conf
@@ -4,8 +4,9 @@ location /v3/actors
     auth_request /_auth;
     error_page 500 /token-revoked.json; 
 
-    
-    proxy_pass http://actors-nginx:80;
+    resolver 127.0.0.11;
+    set $upstream "http://actors-nginx:80";
+    proxy_pass $upstream;
     
 
     proxy_redirect off;

--- a/playbooks/roles/proxy/templates/docker/locations/apps.conf
+++ b/playbooks/roles/proxy/templates/docker/locations/apps.conf
@@ -4,9 +4,8 @@ location /v3/apps
     auth_request /_auth;
     error_page 500 /token-revoked.json; 
 
-    # use var to allow nginx to start even if $upstream is down
-    set $upstream http://apps-api:8080;
-    proxy_pass $upstream;
+    
+    proxy_pass http://apps-api:8080;
 
     proxy_redirect off;
     proxy_set_header Host $host;

--- a/playbooks/roles/proxy/templates/docker/locations/apps.conf
+++ b/playbooks/roles/proxy/templates/docker/locations/apps.conf
@@ -1,11 +1,12 @@
 # apps
 location /v3/apps
-{            
+{          
     auth_request /_auth;
     error_page 500 /token-revoked.json; 
 
-    
-    proxy_pass http://apps-api:8080;
+    resolver 127.0.0.11;
+    set $upstream "http://apps-api:8080;";
+    proxy_pass $upstream;
 
     proxy_redirect off;
     proxy_set_header Host $host;

--- a/playbooks/roles/proxy/templates/docker/locations/authenticator.conf
+++ b/playbooks/roles/proxy/templates/docker/locations/authenticator.conf
@@ -4,8 +4,9 @@ location /v3/oauth2
     auth_request /_auth;
     error_page 500 /token-revoked.json;
 
-    
-    proxy_pass http://authenticator-api:5000;
+    resolver 127.0.0.11;
+    set $upstream "http://authenticator-api:5000";
+    proxy_pass $upstream;
 
     proxy_redirect off;
     proxy_set_header Host $host;

--- a/playbooks/roles/proxy/templates/docker/locations/authenticator.conf
+++ b/playbooks/roles/proxy/templates/docker/locations/authenticator.conf
@@ -4,9 +4,8 @@ location /v3/oauth2
     auth_request /_auth;
     error_page 500 /token-revoked.json;
 
-    # use var to allow nginx to start even if $upstream is down
-    set $upstream http://authenticator-api:5000;
-    proxy_pass $upstream;
+    
+    proxy_pass http://authenticator-api:5000;
 
     proxy_redirect off;
     proxy_set_header Host $host;

--- a/playbooks/roles/proxy/templates/docker/locations/files.conf
+++ b/playbooks/roles/proxy/templates/docker/locations/files.conf
@@ -5,9 +5,8 @@ location /v3/files
     auth_request /_auth;
     error_page 500 /token-revoked.json; 
 
-    # use var to allow nginx to start even if $upstream is down
-    set $upstream http://files-api:8080;
-    proxy_pass $upstream;
+    
+    proxy_pass http://files-api:8080;
 
     proxy_redirect off;
     proxy_set_header Host $host;

--- a/playbooks/roles/proxy/templates/docker/locations/files.conf
+++ b/playbooks/roles/proxy/templates/docker/locations/files.conf
@@ -1,12 +1,13 @@
 
 # files
 location /v3/files
-{            
+{
     auth_request /_auth;
     error_page 500 /token-revoked.json; 
 
-    
-    proxy_pass http://files-api:8080;
+    resolver 127.0.0.11;
+    set $upstream "http://files-api:8080"; 
+    proxy_pass $upstream;
 
     proxy_redirect off;
     proxy_set_header Host $host;

--- a/playbooks/roles/proxy/templates/docker/locations/globus-proxy.conf
+++ b/playbooks/roles/proxy/templates/docker/locations/globus-proxy.conf
@@ -1,11 +1,10 @@
 # globus-proxy
 location /v3/globus-proxy
 {            
-
+    resolver 127.0.0.11;
+    set $upstream "http://globus-proxy:5000";
+    proxy_pass $upstream;
     
-    proxy_pass http://globus-proxy:5000;
-    
-
     proxy_redirect off;
     proxy_set_header Host $host;
 }

--- a/playbooks/roles/proxy/templates/docker/locations/globus-proxy.conf
+++ b/playbooks/roles/proxy/templates/docker/locations/globus-proxy.conf
@@ -2,9 +2,9 @@
 location /v3/globus-proxy
 {            
 
-    # use var to allow nginx to start even if $upstream is down
-    set $upstream http://globus-proxy:5000;
-    proxy_pass $upstream;
+    
+    proxy_pass http://globus-proxy:5000;
+    
 
     proxy_redirect off;
     proxy_set_header Host $host;

--- a/playbooks/roles/proxy/templates/docker/locations/jobs.conf
+++ b/playbooks/roles/proxy/templates/docker/locations/jobs.conf
@@ -4,9 +4,9 @@ location /v3/jobs
     auth_request /_auth;
     error_page 500 /token-revoked.json; 
 
-    # use var to allow nginx to start even if $upstream is down
-    set $upstream http://jobs-api:8080;
-    proxy_pass $upstream;
+    
+    proxy_pass http://jobs-api:8080;
+    
 
     proxy_redirect off;
     proxy_set_header Host $host;

--- a/playbooks/roles/proxy/templates/docker/locations/jobs.conf
+++ b/playbooks/roles/proxy/templates/docker/locations/jobs.conf
@@ -4,8 +4,9 @@ location /v3/jobs
     auth_request /_auth;
     error_page 500 /token-revoked.json; 
 
-    
-    proxy_pass http://jobs-api:8080;
+    resolver 127.0.0.11;
+    set $upstream "http://jobs-api:8080";
+    proxy_pass $upstream;
     
 
     proxy_redirect off;

--- a/playbooks/roles/proxy/templates/docker/locations/meta.conf
+++ b/playbooks/roles/proxy/templates/docker/locations/meta.conf
@@ -5,9 +5,10 @@ location /v3/meta
     auth_request /_auth;
     error_page 500 /token-revoked.json; 
 
-    
-    proxy_pass http://meta:8080;
-    
+    resolver 127.0.0.11;
+    set $upstream "http://meta:8080";
+    proxy_pass $upstream;
+
 
     proxy_redirect off;
     proxy_set_header Host $host;

--- a/playbooks/roles/proxy/templates/docker/locations/meta.conf
+++ b/playbooks/roles/proxy/templates/docker/locations/meta.conf
@@ -5,9 +5,9 @@ location /v3/meta
     auth_request /_auth;
     error_page 500 /token-revoked.json; 
 
-    # use var to allow nginx to start even if $upstream is down
-    set $upstream http://meta:8080;
-    proxy_pass $upstream;
+    
+    proxy_pass http://meta:8080;
+    
 
     proxy_redirect off;
     proxy_set_header Host $host;

--- a/playbooks/roles/proxy/templates/docker/locations/notifications.conf
+++ b/playbooks/roles/proxy/templates/docker/locations/notifications.conf
@@ -4,8 +4,9 @@ location /v3/notifications
     auth_request /_auth;
     error_page 500 /token-revoked.json; 
 
-    
-    proxy_pass http://notifications-api:8080;
+    resolver 127.0.0.11;
+    set $upstream "http://notifications-api:8080";
+    proxy_pass $upstream;
     
 
     proxy_redirect off;

--- a/playbooks/roles/proxy/templates/docker/locations/notifications.conf
+++ b/playbooks/roles/proxy/templates/docker/locations/notifications.conf
@@ -4,9 +4,9 @@ location /v3/notifications
     auth_request /_auth;
     error_page 500 /token-revoked.json; 
 
-    # use var to allow nginx to start even if $upstream is down
-    set $upstream http://notifications-api:8080;
-    proxy_pass $upstream;
+    
+    proxy_pass http://notifications-api:8080;
+    
 
     proxy_redirect off;
     proxy_set_header Host $host;

--- a/playbooks/roles/proxy/templates/docker/locations/pgrest.conf
+++ b/playbooks/roles/proxy/templates/docker/locations/pgrest.conf
@@ -5,9 +5,9 @@ location /v3/pgrest
     auth_request /_auth;
     error_page 500 /token-revoked.json; 
 
-    # use var to allow nginx to start even if $upstream is down
-    set $upstream http://pgrest-api:5000;
-    proxy_pass $upstream;
+    
+    proxy_pass http://pgrest-api:5000;
+    
 
     proxy_redirect off;
     proxy_set_header Host $host;

--- a/playbooks/roles/proxy/templates/docker/locations/pgrest.conf
+++ b/playbooks/roles/proxy/templates/docker/locations/pgrest.conf
@@ -5,8 +5,9 @@ location /v3/pgrest
     auth_request /_auth;
     error_page 500 /token-revoked.json; 
 
-    
-    proxy_pass http://pgrest-api:5000;
+    resolver 127.0.0.11;
+    set $upstream "http://pgrest-api:5000";
+    proxy_pass $upstream;
     
 
     proxy_redirect off;

--- a/playbooks/roles/proxy/templates/docker/locations/pods.conf
+++ b/playbooks/roles/proxy/templates/docker/locations/pods.conf
@@ -2,9 +2,9 @@
 location /v3/pods
 {            
 
-    # use var to allow nginx to start even if $upstream is down
-    set $upstream {{ proxy_service_url }};
-    proxy_pass $upstream;
+    
+    proxy_pass {{ proxy_service_url }};
+    
 
     proxy_redirect off;
     proxy_set_header Host $host;

--- a/playbooks/roles/proxy/templates/docker/locations/pods.conf
+++ b/playbooks/roles/proxy/templates/docker/locations/pods.conf
@@ -2,8 +2,9 @@
 location /v3/pods
 {            
 
-    
-    proxy_pass {{ proxy_service_url }};
+    resolver 127.0.0.11;
+    set $upstream "{{ proxy_service_url }}";
+    proxy_pass $upstream;
     
 
     proxy_redirect off;

--- a/playbooks/roles/proxy/templates/docker/locations/security.conf
+++ b/playbooks/roles/proxy/templates/docker/locations/security.conf
@@ -4,8 +4,9 @@ location /v3/security
     auth_request /_auth;
     error_page 500 /token-revoked.json; 
 
-    
-    proxy_pass http://security-api:8080;
+    resolver 127.0.0.11;
+    set $upstream "http://security-api:8080";
+    proxy_pass $upstream;
     
 
     proxy_redirect off;

--- a/playbooks/roles/proxy/templates/docker/locations/security.conf
+++ b/playbooks/roles/proxy/templates/docker/locations/security.conf
@@ -4,9 +4,9 @@ location /v3/security
     auth_request /_auth;
     error_page 500 /token-revoked.json; 
 
-    # use var to allow nginx to start even if $upstream is down
-    set $upstream http://security-api:8080;
-    proxy_pass $upstream;
+    
+    proxy_pass http://security-api:8080;
+    
 
     proxy_redirect off;
     proxy_set_header Host $host;

--- a/playbooks/roles/proxy/templates/docker/locations/site-router.conf
+++ b/playbooks/roles/proxy/templates/docker/locations/site-router.conf
@@ -3,8 +3,9 @@ location /v3/site-router
 {
     # this location intentionally does NOT get an auth_request directive since the site-router endpoints IS the target of auth_request.
 
-    
-    proxy_pass http://site-router:8000;
+    resolver 127.0.0.11;
+    set $upstream "http://site-router:8000";
+    proxy_pass $upstream;
     
     proxy_redirect off;
     proxy_set_header Host $host;

--- a/playbooks/roles/proxy/templates/docker/locations/site-router.conf
+++ b/playbooks/roles/proxy/templates/docker/locations/site-router.conf
@@ -3,9 +3,9 @@ location /v3/site-router
 {
     # this location intentionally does NOT get an auth_request directive since the site-router endpoints IS the target of auth_request.
 
-    # use var to allow nginx to start even if $upstream is down
-    set $upstream http://site-router:8000;
-    proxy_pass $upstream;
+    
+    proxy_pass http://site-router:8000;
+    
     proxy_redirect off;
     proxy_set_header Host $host;
 }

--- a/playbooks/roles/proxy/templates/docker/locations/sites.conf
+++ b/playbooks/roles/proxy/templates/docker/locations/sites.conf
@@ -5,8 +5,9 @@ location /v3/sites
     auth_request /_auth;
     error_page 500 /token-revoked.json; 
 
-    
-    proxy_pass http://tenants-api:5000;
+    resolver 127.0.0.11;
+    set $upstream "http://tenants-api:5000";
+    proxy_pass $upstream;
     
 
     proxy_redirect off;

--- a/playbooks/roles/proxy/templates/docker/locations/sites.conf
+++ b/playbooks/roles/proxy/templates/docker/locations/sites.conf
@@ -5,9 +5,9 @@ location /v3/sites
     auth_request /_auth;
     error_page 500 /token-revoked.json; 
 
-    # use var to allow nginx to start even if $upstream is down
-    set $upstream http://tenants-api:5000;
-    proxy_pass $upstream;
+    
+    proxy_pass http://tenants-api:5000;
+    
 
     proxy_redirect off;
     proxy_set_header Host localhost:5000;

--- a/playbooks/roles/proxy/templates/docker/locations/streams.conf
+++ b/playbooks/roles/proxy/templates/docker/locations/streams.conf
@@ -4,8 +4,9 @@ location /v3/streams
     auth_request /_auth;
     error_page 500 /token-revoked.json; 
 
-    
-    proxy_pass http://streams-api:5000;
+    resolver 127.0.0.11;
+    set $upstream "http://streams-api:5000";    
+    proxy_pass $upstream;
     
 
     proxy_redirect off;

--- a/playbooks/roles/proxy/templates/docker/locations/streams.conf
+++ b/playbooks/roles/proxy/templates/docker/locations/streams.conf
@@ -4,9 +4,9 @@ location /v3/streams
     auth_request /_auth;
     error_page 500 /token-revoked.json; 
 
-    # use var to allow nginx to start even if $upstream is down
-    set $upstream http://streams-api:5000;
-    proxy_pass $upstream;
+    
+    proxy_pass http://streams-api:5000;
+    
 
     proxy_redirect off;
     proxy_set_header Host $host;

--- a/playbooks/roles/proxy/templates/docker/locations/systems.conf
+++ b/playbooks/roles/proxy/templates/docker/locations/systems.conf
@@ -5,8 +5,9 @@ location /v3/systems
     auth_request /_auth;
     error_page 500 /token-revoked.json; 
 
-    
-    proxy_pass http://systems-api:8080;
+    resolver 127.0.0.11;
+    set $upstream "http://systems-api:8080";
+    proxy_pass $upstream;
     
 
     proxy_redirect off;

--- a/playbooks/roles/proxy/templates/docker/locations/systems.conf
+++ b/playbooks/roles/proxy/templates/docker/locations/systems.conf
@@ -5,9 +5,9 @@ location /v3/systems
     auth_request /_auth;
     error_page 500 /token-revoked.json; 
 
-    # use var to allow nginx to start even if $upstream is down
-    set $upstream http://systems-api:8080;
-    proxy_pass $upstream;
+    
+    proxy_pass http://systems-api:8080;
+    
 
     proxy_redirect off;
     proxy_set_header Host $host;

--- a/playbooks/roles/proxy/templates/docker/locations/tenants.conf
+++ b/playbooks/roles/proxy/templates/docker/locations/tenants.conf
@@ -3,8 +3,10 @@ location /v3/tenants
 {            
     auth_request /_auth;
     error_page 500 /token-revoked.json; 
-    
-    proxy_pass http://tenants-api:5000;            
+
+    resolver 127.0.0.11;
+    set $upstream "http://tenants-api:5000";
+    proxy_pass $upstream;            
     
     proxy_redirect off;
     proxy_set_header Host localhost:5000;

--- a/playbooks/roles/proxy/templates/docker/locations/tenants.conf
+++ b/playbooks/roles/proxy/templates/docker/locations/tenants.conf
@@ -3,10 +3,9 @@ location /v3/tenants
 {            
     auth_request /_auth;
     error_page 500 /token-revoked.json; 
-
-    # use var to allow nginx to start even if $upstream is down
-    set $upstream http://tenants-api:5000;            
-    proxy_pass $upstream;
+    
+    proxy_pass http://tenants-api:5000;            
+    
     proxy_redirect off;
     proxy_set_header Host localhost:5000;
 }

--- a/playbooks/roles/proxy/templates/docker/locations/tokens.conf
+++ b/playbooks/roles/proxy/templates/docker/locations/tokens.conf
@@ -4,8 +4,9 @@ location /v3/tokens
     auth_request /_auth;
     error_page 500 /token-revoked.json; 
 
-    
-    proxy_pass http://tokens-api:5000;
+    resolver 127.0.0.11;
+    set $upstream "http://tokens-api:5000";
+    proxy_pass $upstream;
     
     proxy_redirect off;
     proxy_set_header Host localhost:5000;

--- a/playbooks/roles/proxy/templates/docker/locations/tokens.conf
+++ b/playbooks/roles/proxy/templates/docker/locations/tokens.conf
@@ -4,9 +4,9 @@ location /v3/tokens
     auth_request /_auth;
     error_page 500 /token-revoked.json; 
 
-    # use var to allow nginx to start even if $upstream is down
-    set $upstream http://tokens-api:5000;
-    proxy_pass $upstream;
+    
+    proxy_pass http://tokens-api:5000;
+    
     proxy_redirect off;
     proxy_set_header Host localhost:5000;
 }

--- a/playbooks/roles/proxy/templates/docker/locations/workflows.conf
+++ b/playbooks/roles/proxy/templates/docker/locations/workflows.conf
@@ -4,9 +4,9 @@ location /v3/workflows
     auth_request /_auth;
     error_page 500 /token-revoked.json; 
 
-    # use var to allow nginx to start even if $upstream is down
-    set $upstream http://workflows-api-service:8000;
-    proxy_pass $upstream;
+    
+    proxy_pass http://workflows-api-service:8000;
+    
 
     proxy_redirect off;
     proxy_set_header Host $host;

--- a/playbooks/roles/proxy/templates/docker/locations/workflows.conf
+++ b/playbooks/roles/proxy/templates/docker/locations/workflows.conf
@@ -4,8 +4,9 @@ location /v3/workflows
     auth_request /_auth;
     error_page 500 /token-revoked.json; 
 
-    
-    proxy_pass http://workflows-api-service:8000;
+    resolver 127.0.0.11;
+    set $upstream "http://workflows-api-service:8000";
+    proxy_pass $upstream;
     
 
     proxy_redirect off;

--- a/playbooks/roles/proxy/templates/docker/nginx.conf
+++ b/playbooks/roles/proxy/templates/docker/nginx.conf
@@ -36,9 +36,9 @@ stream {
         proxy_timeout          600s;
         access_log /dev/stdout stream_routing;        # cgarcia- Unsure if this entire 'server' block should be in an if, or if we
         # should what I'm doing here.
-        # use var to allow nginx to start even if $upstream is down
-        set $upstream pods-traefik:80;
-        proxy_pass $upstream;
+        
+        proxy_pass pods-traefik:80;
+        
 
     }
 

--- a/playbooks/roles/proxy/templates/docker/nginx.conf
+++ b/playbooks/roles/proxy/templates/docker/nginx.conf
@@ -30,17 +30,17 @@ stream {
     }
 
     # pods_service. Route TCP to pods-nginx pod.
-    server {
-        listen                 5510;
-        ssl_preread            off;
-        proxy_timeout          600s;
-        access_log /dev/stdout stream_routing;        # cgarcia- Unsure if this entire 'server' block should be in an if, or if we
-        # should what I'm doing here.
+    # server {
+    #     listen                 5510;
+    #     ssl_preread            off;
+    #     proxy_timeout          600s;
+    #     access_log /dev/stdout stream_routing;        # cgarcia- Unsure if this entire 'server' block should be in an if, or if we
+    #     # should what I'm doing here.
         
-        proxy_pass pods-traefik:80;
+    #     proxy_pass pods-traefik:80;
         
 
-    }
+    # }
 
     # Listen for all incoming requests. Preread server name (for mapping). Then pass.
     server {

--- a/playbooks/roles/skadmin/templates/docker/initialLoad/tapis-globus-proxy-secrets.json
+++ b/playbooks/roles/skadmin/templates/docker/initialLoad/tapis-globus-proxy-secrets.json
@@ -1,0 +1,14 @@
+{
+    "secrets": {
+        "servicepwd":[
+            {
+                "tenant":     "{{skadmin_service_tenant_id}}",
+                "user":       "globus-proxy",
+                "secretName": "password",
+                "password":   "<generate-secret>",
+                "kubeSecretName": "tapis-jobs-secrets",
+                "kubeSecretKey":  "service-password"
+            }
+        ]
+    }
+}

--- a/playbooks/roles/skadmin/templates/kube/initialLoad/tapis-globus-proxy-secrets.json
+++ b/playbooks/roles/skadmin/templates/kube/initialLoad/tapis-globus-proxy-secrets.json
@@ -1,0 +1,14 @@
+{
+    "secrets": {
+        "servicepwd":[
+            {
+                "tenant":     "{{skadmin_service_tenant_id}}",
+                "user":       "globus-proxy",
+                "secretName": "password",
+                "password":   "<generate-secret>",
+                "kubeSecretName": "tapis-jobs-secrets",
+                "kubeSecretKey":  "service-password"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
reintroduces the $upstream var, but with a syntax change. Adds resolver directive which seems to fix the problem.