### PR TITLE
Sturdy proxy regardless of Pods + Abaco & Pods fix. 

### DIFF
--- a/playbooks/roles/actors/templates/kube/api/burndown
+++ b/playbooks/roles/actors/templates/kube/api/burndown
@@ -15,7 +15,8 @@ kubectl delete -f nginx.yml
 
 # storage
 kubectl delete -f mongo.yml
-#kubectl delete -f mongo-pvc.yml
-# rabbit can be killed each time. If you drop rabbit, must also kill the pvc.
 kubectl delete -f rabbit.yml
-kubectl delete -f rabbitmq-pvc.yml
+
+# pvc
+# kubectl delete -f mongo-pvc.yml
+# kubectl delete -f rabbitmq-pvc.yml

--- a/playbooks/roles/actors/templates/kube/api/rabbit.yml
+++ b/playbooks/roles/actors/templates/kube/api/rabbit.yml
@@ -12,6 +12,7 @@ spec:
       labels:
         app: actors-rabbit
     spec:
+      hostname: actors-rabbit # sets static hostname rather than k8 generated. Without rabbit can't use pvc to restart.
       containers:
       - name: actors-rabbit
         image: {{ actors_rabbitmq_image }}
@@ -39,4 +40,3 @@ spec:
       - name: actors-rabbitmq-data
         persistentVolumeClaim:
           claimName: {{actors_rabbit_pvc}}
-

--- a/playbooks/roles/pods/templates/kube/nfs-pvc.yml
+++ b/playbooks/roles/pods/templates/kube/nfs-pvc.yml
@@ -9,31 +9,3 @@ spec:
   resources:
     requests:
       storage: 5Gi
-
----
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: pods-nfs-mkdirs
-spec:
-  ttlSecondsAfterFinished: 60
-  template:
-    spec:
-      restartPolicy: Never
-      containers:
-      - name: pods-nfs-vol
-        image: alpine:latest
-        command:
-        - sh
-        - -c
-        - |
-          mkdir -p /podsnfs/volumes
-          mkdir -p /podsnfs/snapshots
-          chmod 777 /podsnfs/volumes /podsnfs/snapshots
-        volumeMounts:
-        - name: pods-nfs-data
-          mountPath: /podsnfs
-      volumes:
-      - name: pods-nfs-data
-        persistentVolumeClaim:
-          claimName: pods-nfs-vol

--- a/playbooks/roles/proxy/templates/kube/nginx/nginx.conf
+++ b/playbooks/roles/proxy/templates/kube/nginx/nginx.conf
@@ -10,45 +10,49 @@ events {
 }
 
 {% if "pods" in proxy_nginx_service_list %}
-### Everything first goes through this stream stanza. Map matches subdomain to port to route to.
-### If no map found, we route to default 8443. This directs back to HTTP stanza as normal.
+# Everything routes through here. Either goes to Pods or HTTP stanza 
 stream {
-
     log_format stream_routing '$remote_addr [$time_local] '
                               'with SNI name "$ssl_preread_server_name" '
                               'proxying to "$instanceport" '
                               '$protocol $status $bytes_sent $bytes_received '
                               '$session_time';
 
-    # 'map' maps input string to output variable. Regex works.
-    # Ports used are purely random. Feel free to change.
+    # 'map's input request SNI (domain name) to output port.
+    # Ports used are purely random
     map $ssl_preread_server_name $instanceport {
-        # Route TCP with following whatever.pods.whatever.tenant.tapis.io to pods-traefik
-        # proxy_nginx_server_name would be `*.develop.tapis.io`, `*.tapis.io`, etc.
+        # *.pods.tenant.environment.tapis.io routes to pods-traefik
         "~*.pods.{{proxy_nginx_server_name}}"    5510;
-        # Route non-pod things to 8443 (arbitrary port, listened to by http stanza) to follow regular nginx walkthrough
+        # Route non-pod requests to 8443 which is read by http stanza
         "~{{proxy_nginx_server_name}}"           8443;
-        # Else default to 5510
-        default                         8443;
+        # Else default to 5510 which routes to pods (required for Postgres)
+        default                         5510;
     }
  
-    # pods_service. Route TCP to pods-traefik pod.
+    # 'pods_upstream' routes to traefik. Backup is HTTP stanza.
+    # Works even if pods_service is down.
+    upstream pods_upstream {
+        server pods-traefik:80;
+        server 127.0.0.1:8443 backup;
+    }
+
+    # 5510 routes to pod_service traefik pod. Backup is HTTP stanza.
     server {
         listen                 5510;
         ssl_preread            off;
         proxy_timeout          600s;
-        access_log /dev/stdout stream_routing;
-        proxy_pass             pods-traefik:80;
-
+        #access_log /dev/stdout stream_routing; # debug log if needed
+        proxy_pass             pods_upstream;
+        proxy_next_upstream    on;
     }
 
     # Listen for all incoming requests. Preread server name (for mapping). Then pass. 
     server {
         listen                  443;
         ssl_preread             on;
-        proxy_connect_timeout   20s;  # max time to connect to pserver
         proxy_timeout           600s;
-        access_log /dev/stdout stream_routing;
+        proxy_connect_timeout   20s;  # max time to connect to pserver
+        #access_log /dev/stdout stream_routing;
         proxy_pass              127.0.0.1:$instanceport;
     }
 }


### PR DESCRIPTION
Proxy only changed for Kube. Added upstream stanza and `proxy_next_upstream`. Tested in dev, and regardless of the state of the Pods service the proxy continues to work.
Abaco rabbitmq couldn't reconnect to pvc due to hostname changing during restarts, set fixed hostname.
Removing old Pods initialization yml. 