### PR TITLE
Jobs/Files early 1.5.0 production release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Notable changes between versions.
 - [ Notifications: 1.4.0 to 1.4.1 (tapis/notifications, notifications-dispatcher)](https://github.com/tapis-project/tapis-notifications/blob/1.4.1/CHANGELOG.md)
 - [ Files: 1.4.2 to 1.4.3 (tapis/tapis-files, tapis/tapis-files-workers)](https://github.com/tapis-project/tapis-files/blob/dev/CHANGELOG.md)
 - [ Jobs: 1.4.2 to 1.4.3 (tapis/jobsworker, jobsmigrate, jobsapi)](https://github.com/tapis-project/tapis-jobs/blob/dev/tapis-jobsapi/CHANGELOG.md)
+- [ Globus-Proxy: 1.4.2 to 1.4.3 (tapis/globus-proxy)](https://github.com/tapis-project/globus-proxy/blob/dev/CHANGELOG.md)
 
 
 ### Breaking Changes for Deployer Admins

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@ Notable changes between versions.
 - [ Systems: 1.4.1 to 1.4.2 (tapis/systems)](https://github.com/tapis-project/tapis-systems/blob/1.4.2/CHANGELOG.md)
 - [ Apps: 1.4.1 to 1.4.2 (tapis/apps)](https://github.com/tapis-project/tapis-apps/blob/1.4.2/CHANGELOG.md)
 - [ Notifications: 1.4.0 to 1.4.1 (tapis/notifications, notifications-dispatcher)](https://github.com/tapis-project/tapis-notifications/blob/1.4.1/CHANGELOG.md)
-- [ Files: 1.4.2 to 1.4.3 (tapis/tapis-files, tapis/tapis-files-workers)](https://github.com/tapis-project/tapis-files/blob/dev/CHANGELOG.md)
-- [ Jobs: 1.4.2 to 1.4.3 (tapis/jobsworker, jobsmigrate, jobsapi)](https://github.com/tapis-project/tapis-jobs/blob/dev/tapis-jobsapi/CHANGELOG.md)
+- [ Files: 1.4.2 to 1.5.0 (tapis/tapis-files, tapis/tapis-files-workers)](https://github.com/tapis-project/tapis-files/blob/dev/CHANGELOG.md)
+- [ Jobs: 1.4.2 to 1.5.0 (tapis/jobsworker, jobsmigrate, jobsapi)](https://github.com/tapis-project/tapis-jobs/blob/dev/tapis-jobsapi/CHANGELOG.md)
 - [ Globus-Proxy: 1.4.2 to 1.4.3 (tapis/globus-proxy)](https://github.com/tapis-project/globus-proxy/blob/dev/CHANGELOG.md)
+
 
 
 ### Breaking Changes for Deployer Admins

--- a/playbooks/roles/actors/templates/kube/api/burndown
+++ b/playbooks/roles/actors/templates/kube/api/burndown
@@ -15,7 +15,8 @@ kubectl delete -f nginx.yml
 
 # storage
 kubectl delete -f mongo.yml
-#kubectl delete -f mongo-pvc.yml
-# rabbit can be killed each time. If you drop rabbit, must also kill the pvc.
 kubectl delete -f rabbit.yml
-kubectl delete -f rabbitmq-pvc.yml
+
+# pvc
+# kubectl delete -f mongo-pvc.yml
+# kubectl delete -f rabbitmq-pvc.yml

--- a/playbooks/roles/actors/templates/kube/api/rabbit.yml
+++ b/playbooks/roles/actors/templates/kube/api/rabbit.yml
@@ -12,6 +12,7 @@ spec:
       labels:
         app: actors-rabbit
     spec:
+      hostname: actors-rabbit # sets static hostname rather than k8 generated. Without rabbit can't use pvc to restart.
       containers:
       - name: actors-rabbit
         image: {{ actors_rabbitmq_image }}
@@ -39,4 +40,3 @@ spec:
       - name: actors-rabbitmq-data
         persistentVolumeClaim:
           claimName: {{actors_rabbit_pvc}}
-

--- a/playbooks/roles/files/defaults/main/images.yml
+++ b/playbooks/roles/files/defaults/main/images.yml
@@ -1,5 +1,5 @@
-files_api_image: tapis/tapis-files:1.4.3
-files_workers_image: tapis/tapis-files-workers:1.4.3
+files_api_image: tapis/tapis-files:1.5.0
+files_workers_image: tapis/tapis-files-workers:1.5.0
 files_postgres_image: postgres:11
 files_migrations_image: postgres:11
 files_minio_image: minio/minio

--- a/playbooks/roles/globus-proxy/defaults/main/images.yml
+++ b/playbooks/roles/globus-proxy/defaults/main/images.yml
@@ -1,1 +1,1 @@
-globus_proxy_api_image: tapis/globus-proxy:1.4.0
+globus_proxy_api_image: tapis/globus-proxy:1.4.3

--- a/playbooks/roles/jobs/defaults/main/images.yml
+++ b/playbooks/roles/jobs/defaults/main/images.yml
@@ -1,6 +1,6 @@
-jobs_api_image: tapis/jobsapi:1.4.3
-jobs_migrations_image: tapis/jobsmigrate:1.4.3
-jobs_worker_image: tapis/jobsworker:1.4.3
+jobs_api_image: tapis/jobsapi:1.5.0
+jobs_migrations_image: tapis/jobsmigrate:1.5.0
+jobs_worker_image: tapis/jobsworker:1.5.0
 jobs_postgres_image: postgres:12.4
 jobs_pgadmin_image: dpage/pgadmin4:6.20
 jobs_rabbitmq_management_image: rabbitmq:3.8.11-management

--- a/playbooks/roles/pods/templates/kube/nfs-pvc.yml
+++ b/playbooks/roles/pods/templates/kube/nfs-pvc.yml
@@ -9,31 +9,3 @@ spec:
   resources:
     requests:
       storage: 5Gi
-
----
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: pods-nfs-mkdirs
-spec:
-  ttlSecondsAfterFinished: 60
-  template:
-    spec:
-      restartPolicy: Never
-      containers:
-      - name: pods-nfs-vol
-        image: alpine:latest
-        command:
-        - sh
-        - -c
-        - |
-          mkdir -p /podsnfs/volumes
-          mkdir -p /podsnfs/snapshots
-          chmod 777 /podsnfs/volumes /podsnfs/snapshots
-        volumeMounts:
-        - name: pods-nfs-data
-          mountPath: /podsnfs
-      volumes:
-      - name: pods-nfs-data
-        persistentVolumeClaim:
-          claimName: pods-nfs-vol

--- a/playbooks/roles/proxy/templates/kube/nginx/nginx.conf
+++ b/playbooks/roles/proxy/templates/kube/nginx/nginx.conf
@@ -10,45 +10,49 @@ events {
 }
 
 {% if "pods" in proxy_nginx_service_list %}
-### Everything first goes through this stream stanza. Map matches subdomain to port to route to.
-### If no map found, we route to default 8443. This directs back to HTTP stanza as normal.
+# Everything routes through here. Either goes to Pods or HTTP stanza 
 stream {
-
     log_format stream_routing '$remote_addr [$time_local] '
                               'with SNI name "$ssl_preread_server_name" '
                               'proxying to "$instanceport" '
                               '$protocol $status $bytes_sent $bytes_received '
                               '$session_time';
 
-    # 'map' maps input string to output variable. Regex works.
-    # Ports used are purely random. Feel free to change.
+    # 'map's input request SNI (domain name) to output port.
+    # Ports used are purely random
     map $ssl_preread_server_name $instanceport {
-        # Route TCP with following whatever.pods.whatever.tenant.tapis.io to pods-traefik
-        # proxy_nginx_server_name would be `*.develop.tapis.io`, `*.tapis.io`, etc.
+        # *.pods.tenant.environment.tapis.io routes to pods-traefik
         "~*.pods.{{proxy_nginx_server_name}}"    5510;
-        # Route non-pod things to 8443 (arbitrary port, listened to by http stanza) to follow regular nginx walkthrough
+        # Route non-pod requests to 8443 which is read by http stanza
         "~{{proxy_nginx_server_name}}"           8443;
-        # Else default to 5510
-        default                         8443;
+        # Else default to 5510 which routes to pods (required for Postgres)
+        default                         5510;
     }
  
-    # pods_service. Route TCP to pods-traefik pod.
+    # 'pods_upstream' routes to traefik. Backup is HTTP stanza.
+    # Works even if pods_service is down.
+    upstream pods_upstream {
+        server pods-traefik:80;
+        server 127.0.0.1:8443 backup;
+    }
+
+    # 5510 routes to pod_service traefik pod. Backup is HTTP stanza.
     server {
         listen                 5510;
         ssl_preread            off;
         proxy_timeout          600s;
-        access_log /dev/stdout stream_routing;
-        proxy_pass             pods-traefik:80;
-
+        #access_log /dev/stdout stream_routing; # debug log if needed
+        proxy_pass             pods_upstream;
+        proxy_next_upstream    on;
     }
 
     # Listen for all incoming requests. Preread server name (for mapping). Then pass. 
     server {
         listen                  443;
         ssl_preread             on;
-        proxy_connect_timeout   20s;  # max time to connect to pserver
         proxy_timeout           600s;
-        access_log /dev/stdout stream_routing;
+        proxy_connect_timeout   20s;  # max time to connect to pserver
+        #access_log /dev/stdout stream_routing;
         proxy_pass              127.0.0.1:$instanceport;
     }
 }

--- a/playbooks/roles/streams/defaults/main/images.yml
+++ b/playbooks/roles/streams/defaults/main/images.yml
@@ -4,4 +4,4 @@ streams_influxdb2_image: influxdb:2.1.1-alpine
 streams_mysql_image: mysql:5.7
 streams_chords_image: ncareol/chords:1.0
 streams_tapis_chords_app_image: scleveland/tapis-chords-app:0.9.8.2.3
-streams_api_image: tapis/streams-api:1.4.0
+streams_api_image: tapis/streams-api:1.5.0


### PR DESCRIPTION
Hi,
Here are the changes we'd like to deploy to production on the morning of 10/10/2023:

Files: 1.4.3 to 1.5.0 (tapis/tapis-files, tapis/tapis-files-workers)
Files changes: https://github.com/tapis-project/tapis-files/blob/dev/CHANGELOG.md

Jobs: 1.4.3 to 1.5.0 (tapis/jobsworker, jobsmigrate, jobsapi)
Jobs changes: https://github.com/tapis-project/tapis-jobs/blob/dev/tapis-jobsapi/CHANGELOG.md