### PR TITLE
Always renew sk-api token creation credentials

### DIFF
--- a/playbooks/roles/security/templates/kube/api/api.yml
+++ b/playbooks/roles/security/templates/kube/api/api.yml
@@ -17,6 +17,8 @@ spec:
 {% if security_renew_sk_script == true %}
       initContainers:
       - name: renew-sk-secret
+        # restartPolicy requires Kubernetes >= 1.28
+        restartPolicy: Always
         command: ["/tmp/renew-sk-secret-script"]
         #command: ["sleep","3600"]
         image: {{ security_skadminutil_image }}

--- a/playbooks/roles/skadmin/templates/kube/renew-sk-secret/renew-sk-secret-script
+++ b/playbooks/roles/skadmin/templates/kube/renew-sk-secret/renew-sk-secret-script
@@ -1,11 +1,45 @@
 #!/bin/bash
 
-export KUBE_TOKEN=`cat /var/run/secrets/kubernetes.io/serviceaccount/token`
-export KUBE_NAMESPACE=`cat /var/run/secrets/kubernetes.io/serviceaccount/namespace`
+while :
+do
+  VAULT_SECRETID=`curl -s -X POST -H "X-Vault-Token: $VAULT_TOKEN" http://vault:8200/v1/auth/approle/role/sk/secret-id | jq -r .data.secret_id`
+  if [ $? -ne 0 ]; then
+    echo "jq filtering of VAULT_SECRETID failed"
+    sleep 10
+    continue
+  fi
+  VAULT_ROLEID=`curl -s -X GET -H "X-Vault-Token: $VAULT_TOKEN" http://vault:8200/v1/auth/approle/role/sk/role-id | jq -r .data.role_id`
+  if [ $? -ne 0 ]; then
+    echo "jq filtering of VAULT_ROLEID failed"
+    sleep 10
+    continue
+  fi
 
-VAULT_SECRETID=`curl -s -X POST -H "X-Vault-Token: $VAULT_TOKEN" {{skadmin_vault_url}}/v1/auth/approle/role/sk/secret-id | jq -r .data.secret_id`
-VAULT_ROLEID=`curl -s -X GET -H "X-Vault-Token: $VAULT_TOKEN" {{skadmin_vault_url}}/v1/auth/approle/role/sk/role-id | jq -r .data.role_id`
+  # no error but no secret_id either?  If so curl must have failed
+  if [ "x${VAULT_SECRETID}" == "xnull" ] || [ "x${VAULT_SECRETID}" == "x" ]; then
+    echo "bad secret_id"
+    sleep 10
+    continue
+  fi
+  
+  # no error but no role_id either?  If so curl must have failed
+  if [ "x${VAULT_ROLEID}" == "xnull" ] || [ "x${VAULT_ROLEID}" == "x" ];  then
+    echo "bad role_id"
+    sleep 10
+    continue
+  fi
 
-kubectl delete secret tapis-sk-vault-secrets
-kubectl create secret generic tapis-sk-vault-secrets --from-literal=vault-secretid=$VAULT_SECRETID --from-literal=vault-roleid=$VAULT_ROLEID
+  # replace kubernetes secret
+  kubectl delete secret tapis-sk-vault-secrets
+  # ignore error if secret didn't exist
+  
+  kubectl create secret generic tapis-sk-vault-secrets --from-literal=vault-secretid=$VAULT_SECRETID --from-literal=vault-roleid=$VAULT_ROLEID
+  if [ $? -ne 0 ]; then
+    echo "creating secret failed"
+    sleep 10
+    continue
+  fi
 
+  # getting here means we successfully replaced the secret with a well-formed one, so we're done
+  break
+done

--- a/playbooks/roles/skadmin/templates/kube/renew-sk-secret/renew-sk-secret-script
+++ b/playbooks/roles/skadmin/templates/kube/renew-sk-secret/renew-sk-secret-script
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+export KUBE_TOKEN=`cat /var/run/secrets/kubernetes.io/serviceaccount/token`
+export KUBE_NAMESPACE=`cat /var/run/secrets/kubernetes.io/serviceaccount/namespace`
+
 while :
 do
   VAULT_SECRETID=`curl -s -X POST -H "X-Vault-Token: $VAULT_TOKEN" http://vault:8200/v1/auth/approle/role/sk/secret-id | jq -r .data.secret_id`


### PR DESCRIPTION
With the Deployer option to use an initContainer to obtain vault token creation credentials for sk-api, you would expect those credentials to be renewed whenever sk-api is restarted by Kubernetes, but that doesn't always happen due to the way Kubernetes works (this is a known design decision discussed elsewhere). This patch levers the new Kubernetes 1.28 option for init containers to have a restart policy. The init container will always restart, and the renewal script will loop until it gets credentials from the vault, ensuring that sk-api is always able to function if the vault is running and unsealed.