### PR TITLE
jobs-files-audit-updates: Update setting for TAPIS_AUDITING_ENABLED

### DIFF
--- a/inventory_example/host_vars/all_services_primary-kube.yml
+++ b/inventory_example/host_vars/all_services_primary-kube.yml
@@ -18,6 +18,9 @@ global_storage_class: rbd-new
 # base URL for the admin tenant in our site
 global_primary_site_admin_tenant_base_url: https://admin.develop.tapis.io
 
+# Flag for audit log recording
+global_auditing_enabled: 'false'
+
 # location of the nginx cert files
 proxy_nginx_cert_file: $HOME/ssl/wild.develop.tapis.io.pem
 proxy_nginx_cert_key: $HOME/ssl/wild.develop.tapis.io.key

--- a/inventory_example/host_vars/min_primary-kube.yml
+++ b/inventory_example/host_vars/min_primary-kube.yml
@@ -20,6 +20,9 @@ global_storage_class: rbd-new
 # base URL for the admin tenant in our site
 global_primary_site_admin_tenant_base_url: https://admin.test.tapis.io
 
+# Flag for audit log recording
+global_auditing_enabled: 'false'
+
 # location of the nginx cert files
 proxy_nginx_cert_file: $HOME/ssl/wild.tapis.io.pem
 proxy_nginx_cert_key: $HOME/ssl/wild.tapis.io.key

--- a/inventory_example/host_vars/tapisquickstart-docker1
+++ b/inventory_example/host_vars/tapisquickstart-docker1
@@ -7,6 +7,9 @@ tapisdatadir: '$HOME/tmp/{{ inventory_hostname }}-data'
 global_tapis_domain: quick.example.com
 global_site_id: tapisquickstart-docker1
 
+# Turn auditing off by default
+global_auditing_enabled: 'false'
+
 # global
 site_type: 1
 

--- a/playbooks/roles/files/defaults/main/vars.yml
+++ b/playbooks/roles/files/defaults/main/vars.yml
@@ -18,5 +18,3 @@ files_postgres_pvc: files-pgdata
 files_postgres16_pvc: files-pg-16-data
 files_node_name: true
 files_use_topology_spread_constraints: true
-files_audit_enabled: false
-

--- a/playbooks/roles/files/templates/docker/docker-compose.yml
+++ b/playbooks/roles/files/templates/docker/docker-compose.yml
@@ -86,6 +86,7 @@ services:
       - RABBITMQ_HOSTNAME=files-rabbitmq
       - RABBITMQ_USERNAME=tapisfiles
       - RABBITMQ_VHOST=tapisfiles
+      - TAPIS_AUDITING_ENABLED={{ global_auditing_enabled }}
     depends_on:
       files-api: 
         condition: service_started
@@ -132,6 +133,7 @@ services:
       - RABBITMQ_HOSTNAME=files-rabbitmq
       - RABBITMQ_USERNAME=tapisfiles
       - RABBITMQ_VHOST=tapisfiles
+      - TAPIS_AUDITING_ENABLED={{ global_auditing_enabled }}
     depends_on:
       files-postgres:
         condition: service_healthy

--- a/playbooks/roles/files/templates/kube/api/deploy.yml
+++ b/playbooks/roles/files/templates/kube/api/deploy.yml
@@ -78,8 +78,8 @@ spec:
             configMapKeyRef:
               name: files-config
               key: globus_client_id
-        - name: TAPIS_AUDIT_ENABLED
-          value: "{{ files_audit_enabled }}"
+        - name: TAPIS_AUDITING_ENABLED
+          value: "{{ global_auditing_enabled }}"
         - name: TAPIS_DB_CONNECTION_POOL_SIZE
           value: "10"
         - name: TAPIS_DB_CONNECTION_POOL_CORE_SIZE

--- a/playbooks/roles/files/templates/kube/worker/deploy.yml
+++ b/playbooks/roles/files/templates/kube/worker/deploy.yml
@@ -78,8 +78,8 @@ spec:
                   name: files-config
                   key: globus_client_id
 {% endif %}
-            - name: TAPIS_AUDIT_ENABLED
-              value: "{{ files_audit_enabled }}"
+            - name: TAPIS_AUDITING_ENABLED
+              value: "{{ global_auditing_enabled }}"
             - name: CHILD_THREAD_POOL_SIZE
               value: "20"
             - name: PARENT_THREAD_POOL_SIZE

--- a/playbooks/roles/get_defaults/defaults/main/vars.yml
+++ b/playbooks/roles/get_defaults/defaults/main/vars.yml
@@ -25,6 +25,8 @@ global_primary_site_admin_tenant_base_url: 'https://{{ global_service_tenant_id 
 global_service_url: '{{ global_primary_site_admin_tenant_base_url }}'
 global_devtenant_url: 'https://{{ global_devtenant_id }}.{{ global_tapis_domain }}'
 
+# Turn auditing off by default
+global_auditing_enabled: 'false'
 
 ### relatively safe defaults below
 

--- a/playbooks/roles/jobs/defaults/main/vars.yml
+++ b/playbooks/roles/jobs/defaults/main/vars.yml
@@ -10,4 +10,3 @@ jobs_rabbitmq_pvc: jobs-rabbitmq-vol01
 jobs_node_selector: null
 jobs_node_name: true
 jobs_port: 8082
-jobs_auditing_enabled: false

--- a/playbooks/roles/jobs/templates/docker/docker-compose.yml
+++ b/playbooks/roles/jobs/templates/docker/docker-compose.yml
@@ -25,7 +25,7 @@ services:
             - TAPIS_QUEUE_USER=jobs
             - TAPIS_REQUEST_LOGGING_FILTER_PREFIXES=/v3/jobs
             - TAPIS_REQUEST_LOGGING_INGORE_SUFFIXES=/healthcheck;/ready;/hello
-            - TAPIS_AUDITING_ENABLED={{ jobs_auditing_enabled }}
+            - TAPIS_AUDITING_ENABLED={{ global_auditing_enabled }}
             - CATALINA_OPTS=-Xms1g -Xmx3g --add-opens java.base/java.time=ALL-UNNAMED
         env_file:
             - {{ tapisdatadir }}/jobs/env
@@ -215,7 +215,7 @@ services:
             - TAPIS_QUEUE_ADMIN_USER=tapis
             - TAPIS_QUEUE_USER=jobs
             - TAPIS_REQUEST_LOGGING_FILTER_PREFIXES=/v3/jobs
-            - TAPIS_AUDITING_ENABLED={{ jobs_auditing_enabled }}
+            - TAPIS_AUDITING_ENABLED={{ global_auditing_enabled }}
             - JAVA_OPTS=-Xms1g -Xmx1g
             - MAIN_CLASS=edu.utexas.tacc.tapis.jobs.worker.JobWorker
             - JOBS_PARMS=-n wkr-DefaultQueue -q tapis.jobq.submit.DefaultQueue -w 100

--- a/playbooks/roles/jobs/templates/docker/jobs-config.env
+++ b/playbooks/roles/jobs/templates/docker/jobs-config.env
@@ -2,4 +2,4 @@ JOBS_SERVICE_SITE_URL={{ jobs_service_url }}
 JOBS_SERVICE_TENANT_ID={{ jobs_service_tenant_id }}
 jobs_site_id={{ jobs_service_site_id }}
 JOBS_SERVICE_NAME={{ jobs_service_name }}
-TAPIS_AUDITING_ENABLED={{ jobs_auditing_enabled }}
+TAPIS_AUDITING_ENABLED={{ global_auditing_enabled }}

--- a/playbooks/roles/jobs/templates/kube/api/api.yml
+++ b/playbooks/roles/jobs/templates/kube/api/api.yml
@@ -84,7 +84,7 @@ spec:
         - name: TAPIS_REQUEST_LOGGING_INGORE_SUFFIXES
           value: "/healthcheck;/ready;/hello"
         - name: TAPIS_AUDITING_ENABLED
-          value: "{{ jobs_auditing_enabled }}"
+          value: "{{ global_auditing_enabled }}"
 #        - name: TAPIS_LOG_DIRECTORY
 #          value: "/opt/tomcat/logs"
         - name: CATALINA_OPTS 

--- a/playbooks/roles/jobs/templates/kube/jobs-config.yml
+++ b/playbooks/roles/jobs/templates/kube/jobs-config.yml
@@ -7,4 +7,4 @@ data:
   "service_tenant_id": "{{jobs_service_tenant_id}}"
   "site_id": "{{jobs_service_site_id}}"
   "service_name": "{{jobs_service_name}}"
-  "tapis_auditing_enabled": "{{jobs_auditing_enabled}}"
+  "tapis_auditing_enabled": "{{global_auditing_enabled}}"

--- a/playbooks/roles/jobs/templates/kube/workers/jobwkr-DefaultQueue.yml
+++ b/playbooks/roles/jobs/templates/kube/workers/jobwkr-DefaultQueue.yml
@@ -73,7 +73,7 @@ spec:
         - name: TAPIS_REQUEST_LOGGING_FILTER_PREFIXES
           value: "/v3/jobs"
         - name: TAPIS_AUDITING_ENABLED
-          value: "{{ jobs_auditing_enabled }}"
+          value: "{{ global_auditing_enabled }}"
         - name: JAVA_OPTS 
           value: "-Xms1g -Xmx4g"
         - name: MAIN_CLASS


### PR DESCRIPTION
Fix incorrect name for auditing flag in Files services.
Create single global setting for enabling auditing for Tapis.