### PR TITLE
Update TMS settings for Systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,24 +2,28 @@
 
 ## 1.8.1
 
-Tapis 1.8.1 contains an update to Java 21 and improved handling of expired service JWTs for all Java based services.
+### Breaking Changes for Deployer Admins
+
+- Note that you must be at Tapis Deployer 1.8.0 before moving to 1.8.1+. Database changes to the files postgres are assumed to have been done, so if you are still on pre-1.8.0, you must do the upgrade to 1.8.0 first.
+- Warning: Support for runtime option SINGULARITY_START has been deprecated. Support will be removed in a future release. If you have a need for this option please contact Tapis support (cicsupport@tacc.utexas.edu).
 
 ### Service Updates
 
-- [Security: 1.8.0 to 1.8.1 (tapis/securitymigrate, securityadmin, securityapi, securityexport)](https://github.com/tapis-project/tapis-security/blob/dev/tapis-securityapi/CHANGELOG.md)
+- Java services (Security, Apps, Files, Jobs, Notifications, Systems) have been updated to use Java 21 (from Java 17).  
+- Java services changes: 
+  - improved handling of expired service JWTs.
+- Security changes:  
   - Add readycheck endpoint.
   - Mark endpoints *ready* and *hello* as deprecated.
-- [Systems: 1.8.0 to 1.8.1 (tapis/systems)](https://github.com/tapis-project/tapis-systems/blob/dev/CHANGELOG.md)
+
+### Service Updates
+
 - [Apps: 1.8.0 to 1.8.1 (tapis/apps)](https://github.com/tapis-project/tapis-apps/blob/dev/CHANGELOG.md)
-  - Bug fix for update of *maxMinutes* using *putApp* endpoint.
-- [Jobs: 1.8.0 to 1.8.1 (tapis/jobsworker, jobsmigrate, jobsapi)](https://github.com/tapis-project/tapis-jobs/blob/dev/tapis-jobsapi/CHANGELOG.md)
-  - Add support for scheduler profile hidden option PARTITION.
-  - Add readycheck endpoint.
-  - Mark endpoints *ready* and *hello* as deprecated.
-- [Files: 1.8.0 to 1.8.1 (tapis/tapis-files, tapis/tapis-files-workers)](https://github.com/tapis-project/tapis-files/blob/dev/CHANGELOG.md)
-  - Improved handling of linux executables during file transfers.
-- [Meta: 1.8.0 to 1.8.1 (tapis/metaapi, tapis-meta-rh-server)](https://github.com/tapis-project/tapis-meta/blob/dev/CHANGELOG.md)
+- [Files: 1.8.0 to 1.8.2 (tapis/tapis-files, tapis/tapis-files-workers)](https://github.com/tapis-project/tapis-files/blob/dev/CHANGELOG.md)
+- [Jobs: 1.8.0 to 1.8.2 (tapis/jobsworker, jobsmigrate, jobsapi)](https://github.com/tapis-project/tapis-jobs/blob/dev/tapis-jobsapi/CHANGELOG.md)
 - [Notifications: 1.8.0 to 1.8.1 (tapis/notifications, notifications-dispatcher)](https://github.com/tapis-project/tapis-notifications/blob/dev/CHANGELOG.md)
+- [Systems: 1.8.0 to 1.8.2 (tapis/systems)](https://github.com/tapis-project/tapis-systems/blob/dev/CHANGELOG.md)
+- [Security: 1.8.0 to 1.8.1 (tapis/securitymigrate, securityadmin, securityapi, securityexport)](https://github.com/tapis-project/tapis-security/blob/dev/tapis-securityapi/CHANGELOG.md)
 
 
 ## 1.8.0
@@ -160,6 +164,7 @@ Tapis 1.6.1 contains a number of new features, enhancements and bug fixes.  In a
   - Refactored codebase to improve reliability.
 - [Notifications: 1.6.0 to 1.6.1 (tapis/notifications, notifications-dispatcher)](https://github.com/tapis-project/tapis-notifications/blob/dev/CHANGELOG.md)
 - [Globus-Proxy: 1.6.0 to 1.6.1 (tapis/globus-proxy)](https://github.com/tapis-project/globus-proxy/blob/dev/CHANGELOG.md)
+
 
 
 ## 1.6.0 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog 
 
+## 1.8.1
+
+Tapis 1.8.1 contains an update to Java 21 and improved handling of expired service JWTs for all Java based services.
+
+### Service Updates
+
+- [Security: 1.8.0 to 1.8.1 (tapis/securitymigrate, securityadmin, securityapi, securityexport)](https://github.com/tapis-project/tapis-security/blob/dev/tapis-securityapi/CHANGELOG.md)
+  - ???.
+- [Systems: 1.8.0 to 1.8.1 (tapis/systems)](https://github.com/tapis-project/tapis-systems/blob/dev/CHANGELOG.md)
+  - Support for Trust Manager System (TMS) ssh keys.
+  - ???.
+- [Apps: 1.8.0 to 1.8.1 (tapis/apps)](https://github.com/tapis-project/tapis-apps/blob/dev/CHANGELOG.md)
+  - Bug fix for update of *maxMinutes* using *putApp* endpoint.
+  - ???.
+- [Jobs: 1.8.0 to 1.8.1 (tapis/jobsworker, jobsmigrate, jobsapi)](https://github.com/tapis-project/tapis-jobs/blob/dev/tapis-jobsapi/CHANGELOG.md)
+  - Add support for scheduler profile hidden option PARTITION.
+  - Add readycheck endpoint.
+  - Mark endpoints *ready* and *hello* as deprecated.
+- [Files: 1.6.0 to 1.6.1 (tapis/tapis-files, tapis/tapis-files-workers)](https://github.com/tapis-project/tapis-files/blob/dev/CHANGELOG.md)
+  - ???.
+- [Notifications: 1.8.0 to 1.8.1 (tapis/notifications, notifications-dispatcher)](https://github.com/tapis-project/tapis-notifications/blob/dev/CHANGELOG.md)
+
+
 ## 1.8.0
 
 ### Breaking Changes for Deployer Admins
@@ -138,7 +161,6 @@ Tapis 1.6.1 contains a number of new features, enhancements and bug fixes.  In a
   - Refactored codebase to improve reliability.
 - [Notifications: 1.6.0 to 1.6.1 (tapis/notifications, notifications-dispatcher)](https://github.com/tapis-project/tapis-notifications/blob/dev/CHANGELOG.md)
 - [Globus-Proxy: 1.6.0 to 1.6.1 (tapis/globus-proxy)](https://github.com/tapis-project/globus-proxy/blob/dev/CHANGELOG.md)
-
 
 
 ## 1.6.0 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,18 @@ Tapis 1.8.1 contains an update to Java 21 and improved handling of expired servi
 ### Service Updates
 
 - [Security: 1.8.0 to 1.8.1 (tapis/securitymigrate, securityadmin, securityapi, securityexport)](https://github.com/tapis-project/tapis-security/blob/dev/tapis-securityapi/CHANGELOG.md)
-  - ???.
+  - Add readycheck endpoint.
+  - Mark endpoints *ready* and *hello* as deprecated.
 - [Systems: 1.8.0 to 1.8.1 (tapis/systems)](https://github.com/tapis-project/tapis-systems/blob/dev/CHANGELOG.md)
-  - Support for Trust Manager System (TMS) ssh keys.
-  - ???.
 - [Apps: 1.8.0 to 1.8.1 (tapis/apps)](https://github.com/tapis-project/tapis-apps/blob/dev/CHANGELOG.md)
   - Bug fix for update of *maxMinutes* using *putApp* endpoint.
-  - ???.
 - [Jobs: 1.8.0 to 1.8.1 (tapis/jobsworker, jobsmigrate, jobsapi)](https://github.com/tapis-project/tapis-jobs/blob/dev/tapis-jobsapi/CHANGELOG.md)
   - Add support for scheduler profile hidden option PARTITION.
   - Add readycheck endpoint.
   - Mark endpoints *ready* and *hello* as deprecated.
-- [Files: 1.6.0 to 1.6.1 (tapis/tapis-files, tapis/tapis-files-workers)](https://github.com/tapis-project/tapis-files/blob/dev/CHANGELOG.md)
-  - ???.
+- [Files: 1.8.0 to 1.8.1 (tapis/tapis-files, tapis/tapis-files-workers)](https://github.com/tapis-project/tapis-files/blob/dev/CHANGELOG.md)
+  - Improved handling of linux executables during file transfers.
+- [Meta: 1.8.0 to 1.8.1 (tapis/metaapi, tapis-meta-rh-server)](https://github.com/tapis-project/tapis-meta/blob/dev/CHANGELOG.md)
 - [Notifications: 1.8.0 to 1.8.1 (tapis/notifications, notifications-dispatcher)](https://github.com/tapis-project/tapis-notifications/blob/dev/CHANGELOG.md)
 
 

--- a/playbooks/roles/apps/defaults/main/images.yml
+++ b/playbooks/roles/apps/defaults/main/images.yml
@@ -1,4 +1,4 @@
-apps_api_image: tapis/apps:1.8.0
+apps_api_image: tapis/apps:1.8.1
 apps_postgres_image: postgres:12.4
 apps_pgadmin_image: dpage/pgadmin4:6.20
 apps_util_image: tapis/ubutil2204:1.8.0

--- a/playbooks/roles/baseburnup/defaults/main/vars.yml
+++ b/playbooks/roles/baseburnup/defaults/main/vars.yml
@@ -1,4 +1,4 @@
-baseburnup_tapis_deployer_version: 1.8.0
+baseburnup_tapis_deployer_version: 1.8.1
 baseburnup_service_url: "{{ global_service_url }}"
 baseburnup_vault_url: "{{ global_vault_url }}"
 

--- a/playbooks/roles/files/defaults/main/images.yml
+++ b/playbooks/roles/files/defaults/main/images.yml
@@ -1,6 +1,6 @@
-files_api_image: tapis/tapis-files:1.8.0
-files_workers_image: tapis/tapis-files-workers:1.8.0
-files_assigner_image: tapis/tapis-files-assigner:1.8.0
+files_api_image: tapis/tapis-files:1.8.1
+files_workers_image: tapis/tapis-files-workers:1.8.1
+files_assigner_image: tapis/tapis-files-assigner:1.8.1
 files_postgres_image: postgres:16
 files_postgres16_image: postgres:16
 files_migrations_image: postgres:11

--- a/playbooks/roles/files/defaults/main/images.yml
+++ b/playbooks/roles/files/defaults/main/images.yml
@@ -1,6 +1,6 @@
-files_api_image: tapis/tapis-files:1.8.1
-files_workers_image: tapis/tapis-files-workers:1.8.1
-files_assigner_image: tapis/tapis-files-assigner:1.8.1
+files_api_image: tapis/tapis-files:1.8.2
+files_workers_image: tapis/tapis-files-workers:1.8.2
+files_assigner_image: tapis/tapis-files-assigner:1.8.2
 files_postgres_image: postgres:16
 files_postgres16_image: postgres:16
 files_migrations_image: postgres:11

--- a/playbooks/roles/jobs/defaults/main/images.yml
+++ b/playbooks/roles/jobs/defaults/main/images.yml
@@ -1,6 +1,6 @@
-jobs_api_image: tapis/jobsapi:1.8.0
-jobs_migrations_image: tapis/jobsmigrate:1.8.0
-jobs_worker_image: tapis/jobsworker:1.8.0
+jobs_api_image: tapis/jobsapi:1.8.1
+jobs_migrations_image: tapis/jobsmigrate:1.8.1
+jobs_worker_image: tapis/jobsworker:1.8.1
 jobs_postgres_image: postgres:12.4
 jobs_pgadmin_image: dpage/pgadmin4:6.20
 jobs_rabbitmq_management_image: rabbitmq:3.8.11-management

--- a/playbooks/roles/jobs/defaults/main/images.yml
+++ b/playbooks/roles/jobs/defaults/main/images.yml
@@ -1,6 +1,6 @@
-jobs_api_image: tapis/jobsapi:1.8.1
-jobs_migrations_image: tapis/jobsmigrate:1.8.1
-jobs_worker_image: tapis/jobsworker:1.8.1
+jobs_api_image: tapis/jobsapi:1.8.2
+jobs_migrations_image: tapis/jobsmigrate:1.8.2
+jobs_worker_image: tapis/jobsworker:1.8.2
 jobs_postgres_image: postgres:12.4
 jobs_pgadmin_image: dpage/pgadmin4:6.20
 jobs_rabbitmq_management_image: rabbitmq:3.8.11-management

--- a/playbooks/roles/meta/defaults/main/images.yml
+++ b/playbooks/roles/meta/defaults/main/images.yml
@@ -1,8 +1,8 @@
-meta_api_image: tapis/metaapi:1.8.0
-meta_rh_server_image: tapis/tapis-meta-rh-server:1.8.0
-meta_mongo_exporter_image: tapis/mqe:1.8.0
-meta_mongo_singlenode_image: tapis/mongo-singlenode:1.8.0
-meta_mongodb_backup_image: tapis/mongodb-backup:1.8.0
-meta_mongobackup_image: tapis/mongobackup:1.8.0
+meta_api_image: tapis/metaapi:1.8.1
+meta_rh_server_image: tapis/tapis-meta-rh-server:1.8.1
+meta_mongo_exporter_image: tapis/mqe:1.8.1
+meta_mongo_singlenode_image: tapis/mongo-singlenode:1.8.1
+meta_mongodb_backup_image: tapis/mongodb-backup:1.8.1
+meta_mongobackup_image: tapis/mongobackup:1.8.1
 meta_alpine_image: alpine:3.17
 meta_util_image: tapis/ubutil2204:1.8.0

--- a/playbooks/roles/notifications/defaults/main/images.yml
+++ b/playbooks/roles/notifications/defaults/main/images.yml
@@ -2,5 +2,5 @@ notifications_postgres_image: postgres:12.4
 notifications_pgadmin_image: dpage/pgadmin4:6.20
 notifications_rabbitmq_image: rabbitmq:3.8.11-management
 notifications_util_image: tapis/ubutil2204:1.8.0
-notifications_api_image: tapis/notifications:1.8.0
-notifications_dispatcher_image: tapis/notifications-dispatcher:1.8.0
+notifications_api_image: tapis/notifications:1.8.1
+notifications_dispatcher_image: tapis/notifications-dispatcher:1.8.1

--- a/playbooks/roles/security/defaults/main/images.yml
+++ b/playbooks/roles/security/defaults/main/images.yml
@@ -1,6 +1,6 @@
 security_pgadmin_image: dpage/pgadmin4:6.20
 security_skadminutil_image: tapis/skadminutil:1.8.0
 security_postgres_image: postgres:12.4
-security_api_image: tapis/securityapi:1.8.0
-security_migrations_image: tapis/securitymigrate:1.8.0
+security_api_image: tapis/securityapi:1.8.1
+security_migrations_image: tapis/securitymigrate:1.8.1
 security_util_image: tapis/ubutil:1.8.0

--- a/playbooks/roles/skadmin/defaults/main/images.yml
+++ b/playbooks/roles/skadmin/defaults/main/images.yml
@@ -1,4 +1,4 @@
-skadmin_securityexport_image: tapis/securityexport:1.8.0
+skadmin_securityexport_image: tapis/securityexport:1.8.1
 skadmin_skadminutil_image: tapis/skadminutil:1.8.0
-skadmin_securityadmin_image: tapis/securityadmin:1.8.0
+skadmin_securityadmin_image: tapis/securityadmin:1.8.1
 skadmin_util_image: tapis/ubutil:1.8.0

--- a/playbooks/roles/systems/defaults/main/images.yml
+++ b/playbooks/roles/systems/defaults/main/images.yml
@@ -1,4 +1,4 @@
 systems_pgadmin_image: dpage/pgadmin4:6.20
 systems_postgres_image: postgres:12.4
 systems_util_image: tapis/ubutil2204:1.8.0
-systems_api_image: tapis/systems:1.8.0
+systems_api_image: tapis/systems:1.8.1

--- a/playbooks/roles/systems/defaults/main/images.yml
+++ b/playbooks/roles/systems/defaults/main/images.yml
@@ -1,4 +1,4 @@
 systems_pgadmin_image: dpage/pgadmin4:6.20
 systems_postgres_image: postgres:12.4
 systems_util_image: tapis/ubutil2204:1.8.0
-systems_api_image: tapis/systems:1.8.1
+systems_api_image: tapis/systems:1.8.2

--- a/playbooks/roles/systems/defaults/main/vars.yml
+++ b/playbooks/roles/systems/defaults/main/vars.yml
@@ -8,11 +8,10 @@ systems_service_url: "{{ global_service_url }}"
 systems_storage_class: "{{ global_storage_class }}"
 systems_postgres_pvc: systems-postgres-vol01
 systems_globus_client_id: null
-systems_tms_enabled: null
+systems_tms_enabled: false
 systems_tms_server_url: null
 systems_tms_tenant: null
 systems_tms_client_id: null
-systems_tms_client_secret: null
 systems_heap_max: 3G
 systems_heap_min: 1G
 systems_port: 8084

--- a/playbooks/roles/systems/templates/kube/api/deploy.yml
+++ b/playbooks/roles/systems/templates/kube/api/deploy.yml
@@ -56,7 +56,6 @@ spec:
               secretKeyRef:
                 name: tapis-systems-secrets
                 key: service-password
-{% if systems_tms_enabled is not none %}
           - name: TAPIS_TMS_ENABLED
             value: "{{ systems_tms_enabled }}"
           - name: TAPIS_TMS_SERVER_URL
@@ -66,5 +65,7 @@ spec:
           - name: TAPIS_TMS_CLIENT_ID
             value: {{ systems_tms_client_id }}
           - name: TAPIS_TMS_CLIENT_SECRET
-            value: {{ systems_tms_client_secret }}
-{% endif %}
+            valueFrom:
+              secretKeyRef:
+                name: tapis-systems-secrets
+                key: tms-client-key


### PR DESCRIPTION
Changes for move of all java based services to version 1.8.1: SK, Systems, Files, Apps, Jobs, Meta.
Update TMS settings for systems, including switching the client key to a kubernetes secret.

Also see github issue #414.