### PR TITLE
Java21 tms

### DIFF
--- a/playbooks/roles/meta/defaults/main/images.yml
+++ b/playbooks/roles/meta/defaults/main/images.yml
@@ -1,8 +1,8 @@
 meta_api_image: tapis/metaapi:1.8.1
-meta_rh_server_image: tapis/tapis-meta-rh-server:1.8.1
-meta_mongo_exporter_image: tapis/mqe:1.8.1
-meta_mongo_singlenode_image: tapis/mongo-singlenode:1.8.1
-meta_mongodb_backup_image: tapis/mongodb-backup:1.8.1
-meta_mongobackup_image: tapis/mongobackup:1.8.1
+meta_rh_server_image: tapis/tapis-meta-rh-server:1.8.0
+meta_mongo_exporter_image: tapis/mqe:1.8.0
+meta_mongo_singlenode_image: tapis/mongo-singlenode:1.8.0
+meta_mongodb_backup_image: tapis/mongodb-backup:1.8.0
+meta_mongobackup_image: tapis/mongobackup:1.8.0
 meta_alpine_image: alpine:3.17
 meta_util_image: tapis/ubutil2204:1.8.0

--- a/playbooks/roles/meta/defaults/main/images.yml
+++ b/playbooks/roles/meta/defaults/main/images.yml
@@ -1,8 +1,8 @@
-meta_api_image: tapis/metaapi:1.8.0
-meta_rh_server_image: tapis/tapis-meta-rh-server:1.8.0
-meta_mongo_exporter_image: tapis/mqe:1.8.0
-meta_mongo_singlenode_image: tapis/mongo-singlenode:1.8.0
-meta_mongodb_backup_image: tapis/mongodb-backup:1.8.0
-meta_mongobackup_image: tapis/mongobackup:1.8.0
+meta_api_image: tapis/metaapi:1.8.1
+meta_rh_server_image: tapis/tapis-meta-rh-server:1.8.1
+meta_mongo_exporter_image: tapis/mqe:1.8.1
+meta_mongo_singlenode_image: tapis/mongo-singlenode:1.8.1
+meta_mongodb_backup_image: tapis/mongodb-backup:1.8.1
+meta_mongobackup_image: tapis/mongobackup:1.8.1
 meta_alpine_image: alpine:3.17
 meta_util_image: tapis/ubutil2204:1.8.0

--- a/playbooks/roles/skadmin/defaults/main/images.yml
+++ b/playbooks/roles/skadmin/defaults/main/images.yml
@@ -1,4 +1,4 @@
-skadmin_securityexport_image: tapis/securityexport:1.8.0
+skadmin_securityexport_image: tapis/securityexport:1.8.1
 skadmin_skadminutil_image: tapis/skadminutil:1.8.0
-skadmin_securityadmin_image: tapis/securityadmin:1.8.0
+skadmin_securityadmin_image: tapis/securityadmin:1.8.1
 skadmin_util_image: tapis/ubutil:1.8.0

--- a/playbooks/roles/systems/defaults/main/vars.yml
+++ b/playbooks/roles/systems/defaults/main/vars.yml
@@ -8,7 +8,7 @@ systems_service_url: "{{ global_service_url }}"
 systems_storage_class: "{{ global_storage_class }}"
 systems_postgres_pvc: systems-postgres-vol01
 systems_globus_client_id: null
-systems_tms_enabled: false
+systems_tms_enabled: null
 systems_tms_server_url: null
 systems_tms_tenant: null
 systems_tms_client_id: null

--- a/playbooks/roles/systems/defaults/main/vars.yml
+++ b/playbooks/roles/systems/defaults/main/vars.yml
@@ -8,11 +8,10 @@ systems_service_url: "{{ global_service_url }}"
 systems_storage_class: "{{ global_storage_class }}"
 systems_postgres_pvc: systems-postgres-vol01
 systems_globus_client_id: null
-systems_tms_enabled: null
+systems_tms_enabled: false
 systems_tms_server_url: null
 systems_tms_tenant: null
 systems_tms_client_id: null
-systems_tms_client_secret: null
 systems_heap_max: 3G
 systems_heap_min: 1G
 systems_port: 8084

--- a/playbooks/roles/systems/templates/kube/api/deploy.yml
+++ b/playbooks/roles/systems/templates/kube/api/deploy.yml
@@ -56,6 +56,7 @@ spec:
               secretKeyRef:
                 name: tapis-systems-secrets
                 key: service-password
+{% if systems_tms_enabled is not none %}
           - name: TAPIS_TMS_ENABLED
             value: "{{ systems_tms_enabled }}"
           - name: TAPIS_TMS_SERVER_URL
@@ -69,3 +70,4 @@ spec:
               secretKeyRef:
                 name: tapis-systems-secrets
                 key: tms-client-key
+{% endif %}

--- a/playbooks/roles/systems/templates/kube/api/deploy.yml
+++ b/playbooks/roles/systems/templates/kube/api/deploy.yml
@@ -56,7 +56,6 @@ spec:
               secretKeyRef:
                 name: tapis-systems-secrets
                 key: service-password
-{% if systems_tms_enabled is not none %}
           - name: TAPIS_TMS_ENABLED
             value: "{{ systems_tms_enabled }}"
           - name: TAPIS_TMS_SERVER_URL
@@ -66,5 +65,7 @@ spec:
           - name: TAPIS_TMS_CLIENT_ID
             value: {{ systems_tms_client_id }}
           - name: TAPIS_TMS_CLIENT_SECRET
-            value: {{ systems_tms_client_secret }}
-{% endif %}
+            valueFrom:
+              secretKeyRef:
+                name: tapis-systems-secrets
+                key: tms-client-key


### PR DESCRIPTION
Update java services meta and SK to 1.8.1. This will complete the move of all java services to java 21.
Update TMS configuration to always include TMS settings, and to get the tms secret from kubernetes.