### PR TITLE
Jobs: Bump worker thread count from 100 to 250. Reduce logging.

### DIFF
--- a/playbooks/roles/jobs/templates/kube/api/deploy.yml
+++ b/playbooks/roles/jobs/templates/kube/api/deploy.yml
@@ -79,8 +79,6 @@ spec:
             secretKeyRef:
               name: tapis-jobs-secrets
               key: rabbitmq-jobs-password
-        - name: TAPIS_REQUEST_LOGGING_FILTER_PREFIXES
-          value: "/v3/jobs"
         - name: TAPIS_REQUEST_LOGGING_INGORE_SUFFIXES
           value: "/healthcheck;/ready;/hello"
         - name: TAPIS_AUDITING_ENABLED
@@ -88,4 +86,4 @@ spec:
 #        - name: TAPIS_LOG_DIRECTORY
 #          value: "/opt/tomcat/logs"
         - name: CATALINA_OPTS 
-          value: "-Xms1g -Xmx3g --add-opens java.base/java.time=ALL-UNNAMED"
+          value: "-Xms1g -Xmx3g --add-opens java.base/java.time=ALL-UNNAMED -Dp6spy.config.modulelist="

--- a/playbooks/roles/jobs/templates/kube/workers/jobwkr-DefaultQueue.yml
+++ b/playbooks/roles/jobs/templates/kube/workers/jobwkr-DefaultQueue.yml
@@ -70,13 +70,11 @@ spec:
             secretKeyRef:
               name: tapis-jobs-secrets
               key: rabbitmq-jobs-password
-        - name: TAPIS_REQUEST_LOGGING_FILTER_PREFIXES
-          value: "/v3/jobs"
         - name: TAPIS_AUDITING_ENABLED
           value: "{{ jobs_auditing_enabled }}"
         - name: JAVA_OPTS 
-          value: "-Xms1g -Xmx4g"
+          value: "-Xms1g -Xmx4g -Dp6spy.config.modulelist="
         - name: MAIN_CLASS
           value: "edu.utexas.tacc.tapis.jobs.worker.JobWorker"
         - name: JOBS_PARMS
-          value: "-n wkr-DefaultQueue -q tapis.jobq.submit.DefaultQueue -w 100"
+          value: "-n wkr-DefaultQueue -q tapis.jobq.submit.DefaultQueue -w 250"


### PR DESCRIPTION
This involves just 2 Jobs deployment files. The update should go in for all three environments.